### PR TITLE
Fixed fastn installer url

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install fastn
         id: install_fastn
         continue-on-error: false
-        run: sh -c "$(curl -fsSL https://raw.githubusercontent.com/ftd-lang/fastn/main/install.sh)"
+        run: sh -c "$(curl -fsSL https://fastn.com/install.sh)"
       - name: Build the pages with fastn
         id: build
         continue-on-error: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install fastn
         id: install_fastn
         continue-on-error: false
-        run: sh -c "$(curl -fsSL https://fastn.com/install.sh)"
+        run: source <(curl -fsSL https://fastn.com/install.sh)
       - name: Build the pages with fastn
         id: build
         continue-on-error: false


### PR DESCRIPTION
Fixed fastn installer url. Earlier it was pointing to the old installer script.